### PR TITLE
Dynamic language dropdowns

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,9 @@ body {
   background-color: #f9f9f9;
   color: #333;
 }
+iconify-icon {
+  font-family: initial !important;
+}
 
 [data-theme="dark"] body,
 [data-theme="dark"] {

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -19,17 +19,27 @@
 			<iconify-icon icon="ph:moon-stars-duotone"></iconify-icon>
 		</button>
 		
-		<!-- Language Dropdown -->
-		<select id="lang-select" class="form-select form-select-sm" aria-label="Language Selector" style="width: auto;">
-			<option value="en">🇬🇧</option>
-			<option value="fr">🇫🇷</option>
-			<option value="es">🇪🇸</option>
-			<option value="de">🇩🇪</option>
-			<option value="pt">🇵🇹</option>
-			<option value="id">🇮🇩</option>
-			<option value="tl">🇵🇭</option>
-			<option value="ar">🇸🇦</option>
-		</select>
+                <!-- Language Dropdown -->
+                <?php
+                        $langFiles = glob(__DIR__ . '/../assets/languages/*.json');
+                        $flags = [
+                                'en' => '🇬🇧',
+                                'fr' => '🇫🇷',
+                                'es' => '🇪🇸',
+                                'de' => '🇩🇪',
+                                'pt' => '🇵🇹',
+                                'id' => '🇮🇩',
+                                'tl' => '🇵🇭',
+                                'ar' => '🇸🇦'
+                        ];
+                ?>
+                <select id="lang-select" class="form-select form-select-sm" aria-label="Language Selector" style="width: auto;">
+                        <?php foreach($langFiles as $file): $code = basename($file, '.json'); ?>
+                                <option value="<?= $code ?>">
+                                        <?= $flags[$code] ?? strtoupper($code) ?>
+                                </option>
+                        <?php endforeach; ?>
+                </select>
 		
 		<!-- User Dropdown -->
 		<div class="dropdown">

--- a/modules/settings/view.php
+++ b/modules/settings/view.php
@@ -7,17 +7,38 @@
 			<button class="btn btn-outline-dark w-100" data-theme-toggle>Toggle Theme</button>
 		</div>
 		
-		<div class="col-md-6">
-			<label class="form-label">Language</label>
-			<select id="lang-select" class="form-select">
-				<option value="en">🇬🇧 English</option>
-				<option value="fr">🇫🇷 Français</option>
-				<option value="de">🇩🇪 Deutsch</option>
-				<option value="es">🇪🇸 Español</option>
-				<option value="pt">🇵🇹 Português</option>
-				<option value="id">🇮🇩 Bahasa Indonesia</option>
-				<option value="tl">🇵🇭 Tagalog</option>
-			</select>
-		</div>
+                <div class="col-md-6">
+                        <label class="form-label">Language</label>
+                        <?php
+                                $langFiles = glob(__DIR__ . '/../../assets/languages/*.json');
+                                $flags = [
+                                        'en' => '🇬🇧',
+                                        'fr' => '🇫🇷',
+                                        'es' => '🇪🇸',
+                                        'de' => '🇩🇪',
+                                        'pt' => '🇵🇹',
+                                        'id' => '🇮🇩',
+                                        'tl' => '🇵🇭',
+                                        'ar' => '🇸🇦'
+                                ];
+                                $names = [
+                                        'en' => 'English',
+                                        'fr' => 'Français',
+                                        'es' => 'Español',
+                                        'de' => 'Deutsch',
+                                        'pt' => 'Português',
+                                        'id' => 'Bahasa Indonesia',
+                                        'tl' => 'Tagalog',
+                                        'ar' => 'العربية'
+                                ];
+                        ?>
+                        <select id="lang-select" class="form-select">
+                                <?php foreach($langFiles as $file): $code = basename($file, '.json'); ?>
+                                        <option value="<?= $code ?>">
+                                                <?= ($flags[$code] ?? strtoupper($code)) . ' ' . ($names[$code] ?? strtoupper($code)) ?>
+                                        </option>
+                                <?php endforeach; ?>
+                        </select>
+                </div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- use languages folder to populate dropdowns in the navbar and settings page
- avoid Poppins overriding iconify icons

## Testing
- `php -l includes/navbar.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853a6bf7fe08326a16f36edf636b2d0