### PR TITLE
Fix language path and add logout key

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Multi-language JSON structure for UI
 
 🗣 Language Support
 All translations reside in /lang/. Want to contribute your own? Simply add a language-code.json file with:
-All translations reside in `assets/languages/`. Want to contribute your own? Simply add a `code.json` file with:
+All translations reside in `includes/languages/`. Want to contribute your own? Simply add a `code.json` file with:
 
 ```
 {

--- a/includes/lang.php
+++ b/includes/lang.php
@@ -5,12 +5,12 @@
 		return $_COOKIE['lang'] ?? 'en';
 	}
 	
-	function getTranslations($lang = null)
-	{
-		$lang = $lang ?? getCurrentLang();
-		$path = __DIR__ . "/../assets/languages/$lang.json";
-		if (file_exists($path)) {
-			return json_decode(file_get_contents($path), true);
-		}
-		return [];
-	}
+        function getTranslations($lang = null)
+        {
+                $lang = $lang ?? getCurrentLang();
+                $path = __DIR__ . "/languages/$lang.json";
+                if (file_exists($path)) {
+                        return json_decode(file_get_contents($path), true);
+                }
+                return [];
+        }

--- a/includes/languages/ar.json
+++ b/includes/languages/ar.json
@@ -93,7 +93,8 @@
     "edit": "تعديل",
     "delete": "حذف",
     "confirm": "تأكيد",
-    "dismiss": "تجاهل"
+    "dismiss": "تجاهل",
+    "logout": "Logout"
   },
   "titles": {
     "dashboard": "لوحة التحكم",

--- a/includes/languages/de.json
+++ b/includes/languages/de.json
@@ -93,8 +93,9 @@
 		"edit": "Bearbeiten",
 		"delete": "Löschen",
 		"confirm": "Bestätigen",
-		"dismiss": "Verwerfen"
-	},
+                "dismiss": "Verwerfen",
+                "logout": "Logout"
+        },
 	"titles": {
 		"dashboard": "Übersicht",
 		"search": "Projekte durchsuchen",

--- a/includes/languages/es.json
+++ b/includes/languages/es.json
@@ -95,7 +95,8 @@
     "edit": "Editar",
     "delete": "Eliminar",
     "confirm": "Confirmar",
-    "dismiss": "Descartar"
+    "dismiss": "Descartar",
+    "logout": "Logout"
   },
   "titles": {
     "dashboard": "Inicio",

--- a/includes/languages/hi.json
+++ b/includes/languages/hi.json
@@ -93,7 +93,8 @@
     "edit": "संपादित करें",
     "delete": "हटाएं",
     "confirm": "पुष्टि करें",
-    "dismiss": "छोड़ें"
+    "dismiss": "छोड़ें",
+    "logout": "Logout"
   },
   "titles": {
     "dashboard": "डैशबोर्ड",

--- a/includes/languages/id.json
+++ b/includes/languages/id.json
@@ -30,5 +30,6 @@
   "delete": "Hapus",
 
   "default_footer": "&copy; 2024<?php echo htmlspecialchars(date('Y')); ?>, Tarek Tarabichi",
-  "made_with_love": "Dibuat dengan <span style=\"color: #e25555;\">&hearts;</span> dan didukung oleh Laragon"
+  "made_with_love": "Dibuat dengan <span style=\"color: #e25555;\">&hearts;</span> dan didukung oleh Laragon",
+  "logout": "Logout"
 }

--- a/includes/languages/pt.json
+++ b/includes/languages/pt.json
@@ -93,8 +93,9 @@
 		"edit": "Editar",
 		"delete": "Excluir",
 		"confirm": "Confirmar",
-		"dismiss": "Dispensar"
-	},
+                "dismiss": "Dispensar",
+                "logout": "Logout"
+        },
 	"titles": {
 		"dashboard": "Painel",
 		"search": "Buscar Projetos",

--- a/includes/languages/tl.json
+++ b/includes/languages/tl.json
@@ -93,8 +93,9 @@
 		"edit": "Ubah",
 		"delete": "Hapus",
 		"confirm": "Konfirmasi",
-		"dismiss": "Tutup"
-	},
+                "dismiss": "Tutup",
+                "logout": "Logout"
+        },
 	"titles": {
 		"dashboard": "Dasbor",
 		"search": "Cari Proyek",

--- a/includes/languages/ur.json
+++ b/includes/languages/ur.json
@@ -93,7 +93,8 @@
     "edit": "ترمیم کریں",
     "delete": "حذف کریں",
     "confirm": "تصدیق کریں",
-    "dismiss": "بند کریں"
+    "dismiss": "بند کریں",
+    "logout": "Logout"
   },
   "titles": {
     "dashboard": "ڈیش بورڈ",

--- a/modules/settings/view.php
+++ b/modules/settings/view.php
@@ -10,7 +10,7 @@
                 <div class="col-md-6">
                         <label class="form-label">Language</label>
                         <?php
-                                $langFiles = glob(__DIR__ . '/../../assets/languages/*.json');
+                                $langFiles = glob(__DIR__ . '/../../includes/languages/*.json');
                                 $flags = [
                                         'en' => '🇬🇧',
                                         'fr' => '🇫🇷',


### PR DESCRIPTION
## Summary
- fix translation paths in lang helper and settings module
- document new languages path in README
- add missing `logout` key across translations

## Testing
- `jq empty includes/languages/*.json`

------
https://chatgpt.com/codex/tasks/task_e_6854345992dc83268e802d215906222a