### PR TITLE
Add language editor page

### DIFF
--- a/modules/settings/language-editor.php
+++ b/modules/settings/language-editor.php
@@ -1,0 +1,89 @@
+<?php
+        require_once '../../includes/functions.php';
+
+        $langDir = realpath(__DIR__ . '/../../includes/languages');
+        $files = glob($langDir . '/*.json');
+        $selected = basename($_GET['file'] ?? $_POST['file'] ?? '');
+        $filePath = $selected ? realpath("$langDir/$selected") : '';
+        if ($filePath && dirname($filePath) !== $langDir) {
+                $filePath = '';
+        }
+
+        $message = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && $filePath) {
+                $json = $_POST['json'] ?? '';
+                $data = json_decode($json, true);
+                if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+                        $message = '<div class="alert alert-danger">Invalid JSON: ' . json_last_error_msg() . '</div>';
+                } else {
+                        file_put_contents($filePath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+                        $message = '<div class="alert alert-success">Language file saved.</div>';
+                }
+        }
+
+        $content = '';
+        if ($filePath && file_exists($filePath)) {
+                $content = file_get_contents($filePath);
+        }
+?>
+
+<div class="container py-4">
+        <h4 class="mb-3">🌐 Language Editor</h4>
+
+        <form method="get" class="mb-3">
+                <label class="form-label">Select File</label>
+                <select name="file" class="form-select" onchange="this.form.submit()">
+                        <option value="">Choose...</option>
+                        <?php foreach ($files as $f): $name = basename($f); ?>
+                                <option value="<?= $name ?>" <?= $name === $selected ? 'selected' : '' ?>><?= $name ?></option>
+                        <?php endforeach; ?>
+                </select>
+        </form>
+
+        <?= $message ?>
+
+        <?php if ($selected): ?>
+                <form method="post" onsubmit="return validateJson();">
+                        <input type="hidden" name="file" value="<?= htmlspecialchars($selected) ?>">
+                        <textarea id="json-editor" name="json" rows="20" class="form-control mb-2"><?= htmlspecialchars($content) ?></textarea>
+                        <div class="mb-2">
+                                <button type="button" class="btn btn-sm btn-secondary" onclick="addGroup()">Add Group</button>
+                                <button type="button" class="btn btn-sm btn-secondary" onclick="addKey()">Add Key</button>
+                                <button type="submit" class="btn btn-sm btn-primary">Save</button>
+                        </div>
+                </form>
+        <?php endif; ?>
+</div>
+
+<script>
+        const editor = document.getElementById('json-editor');
+        function addGroup() {
+                if (!editor) return;
+                try {
+                        const data = editor.value ? JSON.parse(editor.value) : {};
+                        const name = prompt('Group name');
+                        if (!name) return;
+                        if (!data[name]) data[name] = {};
+                        editor.value = JSON.stringify(data, null, 2);
+                } catch (e) { alert('Invalid JSON in editor'); }
+        }
+        function addKey() {
+                if (!editor) return;
+                try {
+                        const data = editor.value ? JSON.parse(editor.value) : {};
+                        const group = prompt('Group');
+                        if (!group) return;
+                        const key = prompt('Key name');
+                        if (!key) return;
+                        const value = prompt('Value');
+                        if (!data[group]) data[group] = {};
+                        data[group][key] = value;
+                        editor.value = JSON.stringify(data, null, 2);
+                } catch (e) { alert('Invalid JSON in editor'); }
+        }
+        function validateJson() {
+                if (!editor) return true;
+                try { JSON.parse(editor.value); return true; }
+                catch (e) { alert('Invalid JSON: ' + e.message); return false; }
+        }
+</script>

--- a/modules/settings/view.php
+++ b/modules/settings/view.php
@@ -1,5 +1,12 @@
+<?php
+        if (isset($_GET['page']) && $_GET['page'] === 'language-editor') {
+                include __DIR__ . '/language-editor.php';
+                return;
+        }
+?>
+
 <div class="container py-4">
-	<h4 class="mb-4">🛠️ Settings</h4>
+        <h4 class="mb-4">🛠️ Settings</h4>
 	
 	<div class="row g-4">
 		<div class="col-md-6">
@@ -40,5 +47,9 @@
                                 <?php endforeach; ?>
                         </select>
                 </div>
-	</div>
+
+                <div class="col-12">
+                        <a href="?module=settings&page=language-editor" class="btn btn-outline-secondary w-100">Edit Language Files</a>
+                </div>
+        </div>
 </div>


### PR DESCRIPTION
## Summary
- add a PHP language editor under settings
- link to the editor from Settings page

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448eb5030832699778b8d366bb553