### PR TITLE
Add email path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ LaragonDash/
 
 Replace the Root Folder
 Simply overwrite your existing root directory with the one from the repo.
-or even create a project (directory too) depends on your preference as I have introduced a variable that reads the root from a config file ProjectPath you simply need to update it to match the location of your www folder
+or even create a project (directory too) depends on your preference as I have introduced a variable that reads the root from a config file ProjectPath you simply need to update it to match the location of your www folder. You can also configure where Laragon stores outgoing mail using `email_output_path`.
 
 **Configure settings.php**
 
@@ -85,10 +85,12 @@ Locate /Includes/config/settings.php and adjust the following to match your setu
         'SSLEnabled' => 1,                        // Enable or disable SSL
         'Port'       => 443,                      // Your local server port
         // Update to your Laragon www path
-        'ProjectPath' => 'D:/laragon8/www/',   
+        'ProjectPath' => 'D:/laragon8/www/',
         // Exclude unwanted files and directories
-        'IgnoreDirs' => ['.', '..', 'templates', 'app', 'includes', 'modules', '.idea', 'logs', 'vendor', 'assets'], 
-        
+        'IgnoreDirs' => ['.', '..', 'templates', 'app', 'includes', 'modules', '.idea', 'logs', 'vendor', 'assets'],
+        // Where Laragon stores outgoing emails
+        'email_output_path' => 'D:/laragon/bin/sendmail/output/',
+
     ];
 ?>
 ```

--- a/includes/config/settings.php
+++ b/includes/config/settings.php
@@ -1,8 +1,10 @@
 <?php
-	return [
-		'SSLEnabled' => 1,
-		'Port'       => 443,
-		'ProjectPath' => 'D:/laragon/www/',  // <- Adjust to YOUR project base directory
-		'IgnoreDirs' => ['.', '..', 'includes', 'modules', '.idea', 'logs', 'vendor', 'assets'],
-	];
+        return [
+                'SSLEnabled' => 1,
+                'Port'       => 443,
+                'ProjectPath' => 'D:/laragon/www/',  // <- Adjust to YOUR project base directory
+                'IgnoreDirs' => ['.', '..', 'includes', 'modules', '.idea', 'logs', 'vendor', 'assets'],
+                // Path where Laragon stores outgoing emails
+                'email_output_path' => 'D:/laragon/bin/sendmail/output/',
+        ];
 ?>

--- a/modules/email/view.php
+++ b/modules/email/view.php
@@ -1,39 +1,22 @@
 <?php
-	
-	// Handle deletion BEFORE any output or includes
-	if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
-		$emailDir = 'D:/laragon/bin/sendmail/output/';
-		$target = basename($_POST['delete']);
-		$fullPath = $emailDir . $target;
-		
-		if (file_exists($fullPath)) {
-			unlink($fullPath);
-			echo "<script>location.href='?module=email&deleted=1';</script>";
-			exit;
-		}
-	}
-	
-	// Now safe to include UI-related files
-	require_once 'includes/functions.php';
-	
-	
-	$emailDir = 'D:/laragon/bin/sendmail/output/';
-	$emails = glob($emailDir . '*.{eml,txt}', GLOB_BRACE);
-	
-	usort($emails, fn($a, $b) => strcmp(basename($b), basename($a))); // DESC by filename
-	
-	$current = $_GET['email'] ?? null;
-	
-	// Handle deletion
-	if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
-		$target = basename($_POST['delete']);
-		$fullPath = $emailDir . $target;
-		if (in_array($fullPath, $emails) && file_exists($fullPath)) {
-			unlink($fullPath);
-			header("Location: ?module=email&deleted=1");
-			exit;
-		}
-	}
+        require_once 'includes/functions.php';
+
+        $emailDir = $laraconfig['email_output_path'] ?? 'D:/laragon/bin/sendmail/output/';
+        $emails = glob($emailDir . '*.{eml,txt}', GLOB_BRACE);
+        usort($emails, fn($a, $b) => strcmp(basename($b), basename($a))); // DESC by filename
+
+        $current = $_GET['email'] ?? null;
+
+        // Handle deletion
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+                $target = basename($_POST['delete']);
+                $fullPath = $emailDir . $target;
+                if (in_array($fullPath, $emails) && file_exists($fullPath)) {
+                        unlink($fullPath);
+                        header("Location: ?module=email&deleted=1");
+                        exit;
+                }
+        }
 ?>
 
 <div class="container-fluid py-4">


### PR DESCRIPTION
## Summary
- configure Laragon email output path via `email_output_path`
- load the new setting in the email module
- document the option in the README

## Testing
- `php -l includes/config/settings.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686236deaa54832691244c0a9349833b