### PR TITLE
Fix module path sanitization

### DIFF
--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,5 +1,5 @@
 <?php
-        $current = $_GET['module'] ?? 'dashboard';
+       $current = basename($_GET['module'] ?? 'dashboard');
 
         require_once __DIR__ . '/lang.php';
         $trans = getTranslations();

--- a/index.php
+++ b/index.php
@@ -14,13 +14,15 @@
 		<!-- Main Content -->
 		<div class="col ps-md-4 pt-4">
 			<?php
-				$module = $_GET['module'] ?? 'dashboard';
-				$path = "modules/$module/view.php";
-				if (file_exists($path)) {
-					include $path;
-				} else {
-					echo "<div class='alert alert-danger'>Module not found.</div>";
-				}
+                               $module = basename($_GET['module'] ?? 'dashboard');
+                               $baseDir = realpath(__DIR__ . '/modules');
+                               $path = realpath(__DIR__ . "/modules/$module/view.php");
+
+                               if ($path && strpos($path, $baseDir) === 0 && file_exists($path)) {
+                                       include $path;
+                               } else {
+                                       echo "<div class='alert alert-danger'>Module not found.</div>";
+                               }
 			?>
 		</div>
 	

--- a/routes.php
+++ b/routes.php
@@ -1,3 +1,10 @@
 <?php
-	$module = $_GET['module'] ?? 'dashboard';
-	include "modules/$module/view.php";
+       $module = basename($_GET['module'] ?? 'dashboard');
+       $baseDir = realpath(__DIR__ . '/modules');
+       $path = realpath(__DIR__ . "/modules/$module/view.php");
+
+       if ($path && strpos($path, $baseDir) === 0 && file_exists($path)) {
+               include $path;
+       } else {
+               echo "<div class='alert alert-danger'>Module not found.</div>";
+       }


### PR DESCRIPTION
## Summary
- sanitize `$_GET['module']` in index and routes
- sanitize sidebar's module lookup
- validate modules reside in the expected directory

## Testing
- `php -l index.php`
- `php -l routes.php`
- `php -l includes/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_686236e8231483268db84223cf5af64e