### PR TITLE
Implement cached project list

### DIFF
--- a/cache/.gitignore
+++ b/cache/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated cache files
+*
+!.gitignore

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -59,37 +59,66 @@
 		return ['name' => 'Unknown', 'icon' => 'mdi:folder-outline', 'admin' => ''];
 	}
 	
-	/**
-	 * Generate a list of valid project tiles
-	 */
-	function getProjectTiles(string $search = ''): array
-	{
-		global $laraconfig;
-		$basePath = $laraconfig['ProjectPath'] ?? '..';
-		$ignored = $laraconfig['IgnoreDirs'] ?? ['.', '..', 'logs', 'vendor', 'assets'];
-		$tiles = [];
-		
-		foreach (scandir($basePath) as $dir) {
-			if (in_array($dir, $ignored)) continue;
-			
-			$fullPath = "$basePath/$dir";
-			if (!is_dir($fullPath)) continue;
-			
-			if (!empty($search) && stripos($dir, $search) === false) continue;
-			
-			$type = detectProjectType($fullPath);
-			
-			$tiles[] = [
-				'name' => $dir,
-				'type' => $type['name'],
-				'icon' => $type['icon'],
-				'link' => getURLScheme() . "://$dir.local",
-				'admin' => $type['admin']
-			];
-		}
-		
-		return $tiles;
-	}
+        /**
+         * Load project tiles from cache or regenerate them.
+         */
+        function getProjectTiles(string $search = ''): array
+        {
+                global $laraconfig;
+
+                $basePath  = $laraconfig['ProjectPath'] ?? '..';
+                $ignored   = $laraconfig['IgnoreDirs'] ?? ['.', '..', 'logs', 'vendor', 'assets'];
+                $cacheDir  = dirname(__DIR__) . '/cache';
+                $cacheFile = "$cacheDir/projects.json";
+                $ttl       = 300; // seconds
+
+                $tiles = [];
+
+                if (file_exists($cacheFile)) {
+                        $cacheTime = filemtime($cacheFile);
+                        $dirTime   = filemtime($basePath);
+
+                        if ((time() - $cacheTime) < $ttl && $dirTime < $cacheTime) {
+                                $data = json_decode(file_get_contents($cacheFile), true);
+                                if (is_array($data)) {
+                                        $tiles = $data;
+                                }
+                        }
+                }
+
+                if (empty($tiles)) {
+                        foreach (scandir($basePath) as $dir) {
+                                if (in_array($dir, $ignored)) continue;
+
+                                $fullPath = "$basePath/$dir";
+                                if (!is_dir($fullPath)) continue;
+
+                                $type = detectProjectType($fullPath);
+
+                                $tiles[] = [
+                                        'name'  => $dir,
+                                        'type'  => $type['name'],
+                                        'icon'  => $type['icon'],
+                                        'link'  => getURLScheme() . "://$dir.local",
+                                        'admin' => $type['admin']
+                                ];
+                        }
+
+                        if (!is_dir($cacheDir)) {
+                                @mkdir($cacheDir, 0777, true);
+                        }
+                        file_put_contents($cacheFile, json_encode($tiles));
+                }
+
+                if ($search) {
+                        $tiles = array_filter($tiles, function ($tile) use ($search) {
+                                return stripos($tile['name'], $search) !== false;
+                        });
+                        $tiles = array_values($tiles);
+                }
+
+                return $tiles;
+        }
 	
 	/**
 	 * Basic server info

--- a/modules/dashboard/functions.php
+++ b/modules/dashboard/functions.php
@@ -9,8 +9,9 @@
 	 * @param string $search
 	 * @return array
 	 */
-	function getDashboardProjects(string $type = '', string $search = ''): array {
-		$projects = getProjectTiles(); // Assumes global helper returns full list
+        function getDashboardProjects(string $type = '', string $search = ''): array {
+                // getProjectTiles() now returns cached data when available
+                $projects = getProjectTiles();
 		$filtered = [];
 		
 		foreach ($projects as $project) {

--- a/modules/dashboard/view.php
+++ b/modules/dashboard/view.php
@@ -3,14 +3,14 @@
 	require_once 'includes/lang.php';
 	require_once 'functions.php';
 	
-	$types = getProjectTypes(); // e.g., from scanning project folders
+        $types = getProjectTypes(); // list is cached by getProjectTiles()
 	
 	// Get filters from request
 	$type = $_GET['type'] ?? '';
 	$search = $_GET['search'] ?? '';
 	
-	// Get projects
-	$projects = getProjectTiles();
+        // Get projects from cache if available
+        $projects = getProjectTiles();
 	
 	// Pagination
 //	$itemsPerPage = 24;

--- a/modules/project/view.php
+++ b/modules/project/view.php
@@ -2,7 +2,8 @@
 	require_once 'includes/functions.php';
 	require_once 'includes/lang.php';
 	
-	$projects = getProjectTiles();
+        // Projects are cached by getProjectTiles()
+        $projects = getProjectTiles();
 	$types = array_unique(array_column($projects, 'type'));
 	sort($types);
 	$colors = ['#FCE7F3', '#DCFCE7', '#E0F2FE', '#FEF9C3', '#FFEDD5', '#EDE9FE'];

--- a/modules/search/data.php
+++ b/modules/search/data.php
@@ -3,8 +3,9 @@
 	
 	header('Content-Type: application/json');
 	
-	$query = strtolower(trim($_GET['q'] ?? ''));
-	$projects = getProjectTiles();
+        $query = strtolower(trim($_GET['q'] ?? ''));
+        // use cached project list
+        $projects = getProjectTiles();
 	
 	$filtered = array_filter($projects, function ($project) use ($query) {
 		if ($query === '') return false;

--- a/modules/search/view.php
+++ b/modules/search/view.php
@@ -2,8 +2,9 @@
 	require_once '../../includes/functions.php';
 	require_once '../../includes/lang.php';
 	
-	$query = $_GET['query'] ?? '';
-	$projects = getProjectTiles();
+        $query = $_GET['query'] ?? '';
+        // getProjectTiles() uses cached data when possible
+        $projects = getProjectTiles();
 	
 	// Simple filter (case-insensitive search in name or path)
 	$filtered = array_filter($projects, function ($p) use ($query) {


### PR DESCRIPTION
## Summary
- cache generated project list into `cache/projects.json`
- use cached project list in dashboard, project and search modules
- ensure cache directory ignored by git

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686236fcd47483268a1aaa6c2f99bf14