### PR TITLE
Implement CSRF protection

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,6 +1,11 @@
 <?php
-	
-	//------------------------------------------
+
+        // Ensure sessions are available for features like CSRF protection
+        if (session_status() === PHP_SESSION_NONE) {
+                session_start();
+        }
+
+        //------------------------------------------
 	// At the top of header.php or index.php during development only
 //	if (file_exists(__DIR__ . '/generate_langs_js.php')) {
 //		include_once __DIR__ . '/generate_langs_js.php';
@@ -14,7 +19,23 @@
 	require_once __DIR__ . '/lang.php';
 
 // Detect theme from cookie or URL
-	$theme = $_COOKIE['theme'] ?? $_GET['theme'] ?? 'light';
+$theme = $_COOKIE['theme'] ?? $_GET['theme'] ?? 'light';
+
+        /**
+         * CSRF token helpers
+         */
+        function getCsrfToken(): string
+        {
+                if (empty($_SESSION['csrf_token'])) {
+                        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+                }
+                return $_SESSION['csrf_token'];
+        }
+
+        function verifyCsrfToken(?string $token): bool
+        {
+                return isset($_SESSION['csrf_token'], $token) && hash_equals($_SESSION['csrf_token'], $token);
+        }
 	
 	/**
 	 * Determine protocol scheme

--- a/modules/email/view.php
+++ b/modules/email/view.php
@@ -1,20 +1,26 @@
 <?php
-	
-	// Handle deletion BEFORE any output or includes
-	if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
-		$emailDir = 'D:/laragon/bin/sendmail/output/';
-		$target = basename($_POST['delete']);
-		$fullPath = $emailDir . $target;
-		
-		if (file_exists($fullPath)) {
-			unlink($fullPath);
-			echo "<script>location.href='?module=email&deleted=1';</script>";
-			exit;
-		}
-	}
-	
-	// Now safe to include UI-related files
-	require_once 'includes/functions.php';
+
+        require_once 'includes/functions.php';
+
+        // Handle deletion BEFORE rendering anything
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+                if (!verifyCsrfToken($_POST['csrf_token'] ?? null)) {
+                        header('HTTP/1.1 400 Bad Request');
+                        echo 'Invalid CSRF token';
+                        exit;
+                }
+
+                $emailDir = 'D:/laragon/bin/sendmail/output/';
+                $target = basename($_POST['delete']);
+                $fullPath = $emailDir . $target;
+
+                if (file_exists($fullPath)) {
+                        unlink($fullPath);
+                        echo "<script>location.href='?module=email&deleted=1';</script>";
+                        exit;
+                }
+        }
+
 	
 	
 	$emailDir = 'D:/laragon/bin/sendmail/output/';
@@ -24,10 +30,16 @@
 	
 	$current = $_GET['email'] ?? null;
 	
-	// Handle deletion
-	if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
-		$target = basename($_POST['delete']);
-		$fullPath = $emailDir . $target;
+        // Handle deletion
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete'])) {
+                if (!verifyCsrfToken($_POST['csrf_token'] ?? null)) {
+                        header('HTTP/1.1 400 Bad Request');
+                        echo 'Invalid CSRF token';
+                        exit;
+                }
+
+                $target = basename($_POST['delete']);
+                $fullPath = $emailDir . $target;
 		if (in_array($fullPath, $emails) && file_exists($fullPath)) {
 			unlink($fullPath);
 			header("Location: ?module=email&deleted=1");
@@ -64,8 +76,9 @@
 							<a href="?module=email&email=<?= urlencode($name) ?>" class="text-decoration-none text-dark flex-grow-1">
 								<?= htmlspecialchars($title) ?>
 							</a>
-							<form method="post" onsubmit="return confirm('Delete this email?')" class="ms-2">
-								<input type="hidden" name="delete" value="<?= htmlspecialchars($name) ?>">
+                                                        <form method="post" onsubmit="return confirm('Delete this email?')" class="ms-2">
+                                                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(getCsrfToken()) ?>">
+                                                                <input type="hidden" name="delete" value="<?= htmlspecialchars($name) ?>">
 								<button class="btn btn-sm btn-outline-danger" title="Delete">&times;</button>
 							</form>
 						</div>

--- a/modules/settings/language-editor.php
+++ b/modules/settings/language-editor.php
@@ -13,17 +13,21 @@
 	$message = '';
 	$content = '';
 	
-	if ($_SERVER['REQUEST_METHOD'] === 'POST' && $filePath) {
-		$json = $_POST['json'] ?? '';
-		$decoded = json_decode($json, true);
-		
-		if (json_last_error() !== JSON_ERROR_NONE) {
-			$message = '<div class="alert alert-danger">❌ Invalid JSON: ' . json_last_error_msg() . '</div>';
-		} else {
-			file_put_contents($filePath, json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-			$message = '<div class="alert alert-success">✅ Language file saved.</div>';
-		}
-	}
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && $filePath) {
+                if (!verifyCsrfToken($_POST['csrf_token'] ?? null)) {
+                        $message = '<div class="alert alert-danger">Invalid CSRF token</div>';
+                } else {
+                        $json = $_POST['json'] ?? '';
+                        $decoded = json_decode($json, true);
+
+                        if (json_last_error() !== JSON_ERROR_NONE) {
+                                $message = '<div class="alert alert-danger">❌ Invalid JSON: ' . json_last_error_msg() . '</div>';
+                        } else {
+                                file_put_contents($filePath, json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+                                $message = '<div class="alert alert-success">✅ Language file saved.</div>';
+                        }
+                }
+        }
 	
 	if ($filePath && file_exists($filePath)) {
 		$content = file_get_contents($filePath);
@@ -58,8 +62,9 @@
 	<?= $message ?>
 	
 	<?php if ($selected): ?>
-		<form method="post" onsubmit="return validateJson();">
-			<input type="hidden" name="file" value="<?= htmlspecialchars($selected) ?>">
+                <form method="post" onsubmit="return validateJson();">
+                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(getCsrfToken()) ?>">
+                        <input type="hidden" name="file" value="<?= htmlspecialchars($selected) ?>">
 			<textarea id="json-editor" name="json" rows="20" class="form-control mb-2"><?= htmlspecialchars($content) ?></textarea>
 			<div class="mb-2">
 				<button type="button" class="btn btn-sm btn-secondary" onclick="addGroup()">

--- a/modules/settings/settings-editor.php
+++ b/modules/settings/settings-editor.php
@@ -16,7 +16,8 @@
 
 <div class="container py-4">
 	<h4 class="mb-4">⚙️ System Configuration</h4>
-	<form method="post" action="update.php">
+        <form method="post" action="update.php">
+                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(getCsrfToken()) ?>">
 		<!-- Ignored Folders -->
 		<div class="mb-3">
 			<label class="form-label">Ignored Directories</label>

--- a/modules/settings/update.php
+++ b/modules/settings/update.php
@@ -3,10 +3,16 @@
 	
 	$configPath = realpath(__DIR__ . '/../../includes/config/settings.php');
 	
-	if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-		header('Location: ../../index.php?module=settings');
-		exit;
-	}
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                header('Location: ../../index.php?module=settings');
+                exit;
+        }
+
+        if (!verifyCsrfToken($_POST['csrf_token'] ?? null)) {
+                header('HTTP/1.1 400 Bad Request');
+                echo 'Invalid CSRF token';
+                exit;
+        }
 	
 	$config = is_file($configPath) ? include $configPath : [];
 


### PR DESCRIPTION
## Summary
- start sessions in `functions.php` and add helpers for CSRF token creation and validation
- embed CSRF token hidden inputs in forms
- validate CSRF tokens in settings update, email deletion, and language editor

## Testing
- `php -l includes/functions.php`
- `php -l modules/settings/settings-editor.php`
- `php -l modules/settings/update.php`
- `php -l modules/settings/language-editor.php`
- `php -l modules/email/view.php`


------
https://chatgpt.com/codex/tasks/task_e_686236fa3d78832682f5802b198b4970